### PR TITLE
Titanic wrangling

### DIFF
--- a/titanic/titanicML.ipynb
+++ b/titanic/titanicML.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "# TITANIC Part II\n",
     "\n",
-    "## Machine Learning from Disaster: Introduction to Scikit-Learn"
+    "## Machine Learning from Disaster: Introduction to `scikit-learn`"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# re-establish database connection\n",
+    "# Re-establish database connection\n",
     "con = sql.connect(\"titanic.db\") "
    ]
   },
@@ -43,8 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# figure out the name of the table you saved your data to\n",
-    "\n",
+    "# Figure out the name of the table you saved your data to\n",
     "cursor = con.cursor()\n",
     "cursor.execute(\"SELECT name FROM sqlite_master WHERE type='table';\")\n",
     "print(cursor.fetchall())"
@@ -56,8 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# extract everything from the 'training_data' table (or whatever you called it) into a dataframe\n",
-    "train = pd_sql.read_sql('select * from titanic', con, index_col='index').reset_index()"
+    "# Extract everything from the 'training_data' table (or whatever you called it) into a dataframe\n",
+    "train = pd_sql.read_sql('select * from training_data', con, index_col='index').reset_index()"
    ]
   },
   {
@@ -66,8 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Is it all still here?\n",
-    "train.head(5)"
+    "# Is it all still here?\n",
+    "train.head()"
    ]
   },
   {
@@ -76,7 +75,7 @@
    "source": [
     "### Creating a Model: A Naive Approach    \n",
     "\n",
-    "Let's start by creating a model that predicts purely based on gender"
+    "Let's start by creating a model that predicts purely based on gender."
    ]
   },
   {
@@ -124,11 +123,11 @@
     "\n",
     "But that means our predictions are going to be wrong sometimes -- for about a quarter of the women and a fifth of the men. Let's use the Python library Scikit-learn to see if we can do a little better!\n",
     "\n",
-    "## Using Scikit-learn\n",
+    "## Using `scikit-learn`\n",
     "\n",
-    "Scikit-Learn is a powerful machine learning library implemented in Python with numeric and scientific computing powerhouses Numpy, Scipy, and matplotlib for extremely fast analysis of small to medium-sized data sets. It is open source, commercially usable and contains many modern machine learning algorithms for classification, regression, clustering, feature extraction, and optimization. For this reason Scikit-Learn is often the first tool in a data scientist's toolkit for machine learning of incoming data sets.\n",
+    "`Scikit-learn` is a powerful machine learning library implemented in Python with numeric and scientific computing powerhouses `NumPy`, `SciPy`, and `matplotlib` for extremely fast analysis of small to medium-sized data sets. It is open source, commercially usable and contains many modern machine learning algorithms for classification, regression, clustering, feature extraction, and optimization. For this reason, `scikit-learn` is often the first tool in a data scientist's toolkit for machine learning of incoming data sets.\n",
     "\n",
-    "Scikit-learn will expect numeric values and no blanks, so first we need to do a bit more wrangling."
+    "`Scikit-learn` will expect numeric values and no blanks, so first we need to do a bit more wrangling."
    ]
   },
   {
@@ -225,7 +224,7 @@
    "outputs": [],
    "source": [
     "# Initialize our algorithm\n",
-    "lr = LogisticRegression(random_state=1)"
+    "lr = LogisticRegression(random_state=1, solver='liblinear')"
    ]
   },
   {
@@ -259,6 +258,7 @@
     "        \"PassengerId\": test[\"PassengerId\"],\n",
     "        \"Survived\": predictions\n",
     "    })\n",
+    "\n",
     "test_predictions.head(10)"
    ]
   },
@@ -272,8 +272,8 @@
     "\n",
     "For Kaggle, the training samples are constructed by splitting our original dataset into more than one part. But what if certain chunks of our data have more variance than others? We want to ensure that our model performs just as well regardless of the particular way the data are divided up. So let's go back and do some cross-validation splits.    \n",
     "\n",
-    "More on cross-validation tools inside Scikit-learn here:    \n",
-    "http://scikit-learn.org/stable/modules/generated/sklearn.cross_validation.train_test_split.html"
+    "More on cross-validation tools inside scikit-learn here:    \n",
+    "https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html"
    ]
   },
   {
@@ -294,7 +294,11 @@
    "source": [
     "X = train[[\"Pclass\", \"Sex\", \"Age\", \"SibSp\"]]\n",
     "y = train[\"Survived\"]\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X,y,test_size = 0.2)\n",
+    "\n",
+    "# Split your data into training and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+    "\n",
+    "# Fit the training data to the model\n",
     "log_reg = lr.fit(X_train, y_train)"
    ]
   },
@@ -333,7 +337,7 @@
    "source": [
     "expected   = y_test\n",
     "predicted  = log_reg.predict(X_test)\n",
-    "classificationReport = classification_report(expected, predicted, target_names=[\"Perished\",\"Survived\"])\n",
+    "classificationReport = classification_report(expected, predicted, target_names=[\"Perished\", \"Survived\"])\n",
     "print(classificationReport)"
    ]
   },
@@ -372,6 +376,7 @@
     "        \"PassengerId\": test[\"PassengerId\"],\n",
     "        \"Survived\": predictions\n",
     "    })\n",
+    "\n",
     "kgl_submission_lr.to_csv('lr_model.csv', index=False)"
    ]
   },
@@ -386,7 +391,7 @@
     "A random forest is a 'meta estimator'. It will fit a number of decision trees (we'll have to tell it how many) on various sub-samples of the dataset. Then it will use averaging to improve the predictive accuracy and control over-fitting.    \n",
     "\n",
     "Read more about Random Forests here:    \n",
-    "http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html"
+    "https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html"
    ]
   },
   {
@@ -414,8 +419,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Next split up the data with the 'train test split' method in the Cross Validation module\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X,y, test_size=0.2)\n",
+    "# Next split your data into training and test sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)\n",
     "\n",
     "# ...and then run the 'fit' method to build a forest of trees\n",
     "rf.fit(X_train, y_train)"
@@ -438,7 +443,7 @@
    "source": [
     "expected   = y_test\n",
     "predicted  = rf.predict(X_test)\n",
-    "classificationReport = classification_report(expected, predicted, target_names=[\"Perished\",\"Survived\"])\n",
+    "classificationReport = classification_report(expected, predicted, target_names=[\"Perished\", \"Survived\"])\n",
     "print(classificationReport)"
    ]
   },
@@ -517,6 +522,7 @@
     "        \"PassengerId\": test[\"PassengerId\"],\n",
     "        \"Survived\": predictions\n",
     "    })\n",
+    "\n",
     "kgl_submission_rf.to_csv('rf_model.csv', index=False)"
    ]
   },
@@ -551,9 +557,9 @@
     "\n",
     "for kernel in kernels:\n",
     "    if kernel != 'poly':\n",
-    "        model      = SVC(kernel=kernel)\n",
+    "        model      = SVC(kernel=kernel, gamma='auto')\n",
     "    else:\n",
-    "        model      = SVC(kernel=kernel, degree=3)\n",
+    "        model      = SVC(kernel=kernel, degree=3, gamma='auto')\n",
     "\n",
     "model.fit(X_train, y_train)\n",
     "expected   = y_test\n",
@@ -578,6 +584,7 @@
    "outputs": [],
    "source": [
     "from sklearn.metrics import precision_recall_curve\n",
+    "\n",
     "precision, recall, thresholds = precision_recall_curve(y_test, predicted)  \n",
     "decision_threshold = np.append(thresholds, 1)\n",
     "\n",
@@ -604,6 +611,7 @@
     "        \"PassengerId\": test[\"PassengerId\"],\n",
     "        \"Survived\": predictions\n",
     "    })\n",
+    "\n",
     "kgl_submission_svm.to_csv('svm_model.csv', index=False)"
    ]
   },
@@ -623,16 +631,15 @@
     "This tutorial is based on the Kaggle Competition, \"Predicting Survival Aboard the Titanic\"    \n",
     "https://www.kaggle.com/c/titanic    \n",
     "\n",
-    "As well as the following tutorials:    \n",
-    "https://www.kaggle.com/mlchang/titanic/logistic-model-using-scikit-learn/run/91385    \n",
-    "https://www.kaggle.com/c/titanic/details/getting-started-with-random-forests    \n",
+    "As well as the following tutorials:       \n",
+    "https://www.kaggle.com/alexisbcook/titanic-tutorial  \n",
     "https://github.com/savarin/pyconuk-introtutorial/tree/master/notebooks    \n",
     "\n",
     "See also:    \n",
-    "http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html    \n",
-    "http://scikit-learn.org/stable/modules/generated/sklearn.cross_validation.train_test_split.html    \n",
-    "http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html    \n",
-    "http://scikit-learn.org/stable/modules/svm.html      "
+    "https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html   \n",
+    "https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html   \n",
+    "https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html  \n",
+    "https://scikit-learn.org/stable/modules/svm.html   "
    ]
   }
  ],
@@ -652,7 +659,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/titanic/titanic_wrangling.ipynb
+++ b/titanic/titanic_wrangling.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "=> Load the ```train.csv``` file into a ```pandas``` ```DataFrame```.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html"
    ]
   },
   {
@@ -69,7 +69,7 @@
    "source": [
     "=> Use ```pandas``` to view the \"head\" of the file with the first 10 rows.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.head.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.head.html"
    ]
   },
   {
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to view the first 10 rows of the file."
+    "# Use pandas to view the first 10 rows of the file\n"
    ]
   },
   {
@@ -103,7 +103,7 @@
     "\n",
     "__=>__ Use ```pandas``` to get summary statistics on the numerical fields in the data.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.describe.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.describe.html"
    ]
   },
   {
@@ -114,7 +114,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to get the summary statistics on the data."
+    "# Use pandas to get the summary statistics on the data\n"
    ]
   },
   {
@@ -122,10 +122,10 @@
    "metadata": {},
    "source": [
     "*What can we infer from the summary statistics?*\n",
-    " * How many missing values does the ```Age``` column have?\n",
+    " * How many missing values does the `Age` column have?\n",
     " * What percentage of the passengers survived?\n",
     " * How many passengers traveled in Class 3?\n",
-    " * Are there any outliers in the ```Fare``` column?"
+    " * Are there any outliers in the `Fare` column?"
    ]
   },
   {
@@ -134,7 +134,7 @@
    "source": [
     "__=>__ Use ```pandas``` to get the median of the ```Age``` column.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.median.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.median.html"
    ]
   },
   {
@@ -145,7 +145,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to get the median of the Age column."
+    "# Use pandas to get the median of the Age column\n"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "source": [
     "__=>__ Use ```pandas``` to find the number of unique values in the ```Ticket``` column.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.nunique.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.nunique.html"
    ]
   },
   {
@@ -165,7 +165,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to find the number of unique values in the Ticket column."
+    "# Use pandas to find the number of unique values in the Ticket column\n"
    ]
   },
   {
@@ -176,7 +176,7 @@
     "\n",
     "__=>__ Use ```pandas``` to count the number of each unique value in the ```Ticket``` column.\n",
     "\n",
-    "Documentation: http://pandas.pydata.org/pandas-docs/version/0.20.3/generated/pandas.Series.value_counts.html"
+    "Documentation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.value_counts.html"
    ]
   },
   {
@@ -187,7 +187,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to count the number of each unique Ticket value."
+    "# Use pandas to count the number of each unique Ticket value\n"
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "for idx in df.index:\n",
     "    if df.loc[idx].Fare > 500:\n",
-    "        df.set_value(idx, 'Fare', 263.0000)"
+    "        df.at[idx, 'Fare'] = 263.0000"
    ]
   },
   {
@@ -298,8 +298,8 @@
     "__=>__ Use ```pandas``` to get the sum of all the null values in the ```Cabin``` column.\n",
     "\n",
     "Documentation:    \n",
-    "http://pandas.pydata.org/pandas-docs/stable/generated/pandas.isnull.html    \n",
-    "http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.sum.html"
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.isnull.html  \n",
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.sum.html"
    ]
   },
   {
@@ -310,7 +310,7 @@
    },
    "outputs": [],
    "source": [
-    "# Sum the number of null Cabin values."
+    "# Sum the number of null Cabin values\n"
    ]
   },
   {
@@ -323,7 +323,7 @@
     "__=>__ Since most of the ```Cabin``` values are missing, let's use ```pandas``` to drop the column. We will also drop the ```Ticket``` column, since as we saw earlier, it contains of a mix of text and numeric data that doesn't appear to contain any useful information. *HINT: remember to set ```axis=1```.*\n",
     "\n",
     "Documentation:  \n",
-    "http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.drop.html  \n",
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.drop.html\n",
     "https://chrisalbon.com/python/pandas_dropping_column_and_rows.html"
    ]
   },
@@ -335,7 +335,7 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to drop the Cabin and Ticket columns."
+    "# Use pandas to drop the Cabin and Ticket columns\n"
    ]
   },
   {
@@ -348,8 +348,8 @@
     "__=>__ First use ```pandas``` to calculate and save the mean age of the passengers. Then replace the null values in the ```Age``` column with that number.\n",
     "\n",
     "Documentation:  \n",
-    "http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.mean.html     \n",
-    "http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.fillna.html"
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.mean.html  \n",
+    "https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.fillna.html"
    ]
   },
   {
@@ -363,7 +363,7 @@
     "# First, use pandas to find the mean age of the passengers: mean_age\n",
     "mean_age = \n",
     "\n",
-    "# ...and then fill in the null Age values with mean_age."
+    "# ...and then fill in the null Age values with mean_age"
    ]
   },
   {
@@ -374,7 +374,7 @@
    },
    "outputs": [],
    "source": [
-    "# Check that there are no more null values in the Age column."
+    "# Check that there are no more null values in the Age column\n"
    ]
   },
   {
@@ -406,7 +406,7 @@
    "source": [
     "__=>__ Use ```pandas``` to write your ```DataFrame``` to the ```sqlite``` database.\n",
     "\n",
-    "Documenation: http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_sql.html"
+    "Documenation: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html"
    ]
   },
   {
@@ -417,7 +417,17 @@
    },
    "outputs": [],
    "source": [
-    "# Use pandas to save your dataframe to a sqlite database name 'training_data'."
+    "# Use pandas to save your dataframe to a sqlite database name 'training_data'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close your connection to the database\n",
+    "con.close()"
    ]
   }
  ],
@@ -437,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In `titanic_wrangling.ipynb`:
- Updated hyperlinks to Pandas documentation
- Replaced deprecated `set_value` method with the recommended `at` method
- Added additional cell at the end of the notebook to close the database connection

In `titanicML.ipynb`:
- Explicitly set the `gamma` parameter for the `SVM` model and the `solver` parameter for the `LogisticRegression` model in order to silence warnings about upcoming changes
- Updated documentation hyperlinks and removed link to Kaggle tutorial that is no longer available online
- Replaced `from sklearn.cross_validation import train_test_split` import statement with `from sklearn.model_selection import train_test_split`